### PR TITLE
Decouple EventsQueue from Aggregate

### DIFF
--- a/example/aggregate/postcard/postcard.go
+++ b/example/aggregate/postcard/postcard.go
@@ -2,6 +2,7 @@ package postcard
 
 import (
 	"fmt"
+
 	"github.com/ThreeDotsLabs/esja/pkg/aggregate"
 )
 
@@ -20,9 +21,8 @@ type Postcard struct {
 
 func NewPostcard(id string) (*Postcard, error) {
 	p := &Postcard{}
-	p.eq = aggregate.NewEventsQueue(p)
 
-	err := p.eq.PushAndApply(&Created{
+	err := p.record(&Created{
 		ID: id,
 	})
 	if err != nil {
@@ -36,13 +36,17 @@ func (p *Postcard) PopEvents() []aggregate.VersionedEvent[*Postcard] {
 	return p.eq.PopEvents()
 }
 
-func (p *Postcard) FromEvents(events []aggregate.VersionedEvent[*Postcard]) error {
-	es, err := aggregate.NewEventsQueueFromEvents(p, events)
-	if err != nil {
-		return err
+func (p *Postcard) FromEventsQueue(eq aggregate.EventsQueue[*Postcard]) error {
+	events := eq.PopEvents()
+
+	for _, e := range events {
+		err := e.Apply(p)
+		if err != nil {
+			return err
+		}
 	}
 
-	p.eq = es
+	p.eq = eq
 
 	return nil
 }
@@ -56,13 +60,13 @@ func (p *Postcard) AggregateID() aggregate.ID {
 }
 
 func (p *Postcard) Write(content string) error {
-	return p.eq.PushAndApply(&Written{
+	return p.record(&Written{
 		Content: content,
 	})
 }
 
 func (p *Postcard) Address(sender Address, addressee Address) error {
-	return p.eq.PushAndApply(&Addressed{
+	return p.record(&Addressed{
 		Sender:    sender,
 		Addressee: addressee,
 	})
@@ -73,7 +77,7 @@ func (p *Postcard) Send() error {
 		return fmt.Errorf("postcard already sent")
 	}
 
-	return p.eq.PushAndApply(&Sent{})
+	return p.record(&Sent{})
 }
 
 func (p *Postcard) Sender() Address {
@@ -90,4 +94,15 @@ func (p *Postcard) Content() string {
 
 func (p *Postcard) Sent() bool {
 	return p.sent
+}
+
+func (p *Postcard) record(e aggregate.Event[*Postcard]) error {
+	err := e.Apply(p)
+	if err != nil {
+		return err
+	}
+
+	p.eq.Record(e)
+
+	return nil
 }

--- a/example/aggregate/postcard/postcard_test.go
+++ b/example/aggregate/postcard/postcard_test.go
@@ -57,8 +57,11 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	}
 	assert.Equal(expectedEvents, events)
 
+	eq, err := aggregate.NewEventsQueueFromEvents(events)
+	assert.NoError(err)
+
 	pcLoaded := postcard.Postcard{}
-	err = pcLoaded.FromEvents(events)
+	err = pcLoaded.FromEventsQueue(eq)
 	assert.NoError(err)
 
 	assert.Equal(senderAddress, pcLoaded.Sender())

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -38,7 +38,7 @@ package aggregate
 type Aggregate[A any] interface {
 	AggregateID() ID
 	PopEvents() []VersionedEvent[A]
-	FromEvents(events []VersionedEvent[A]) error
+	FromEventsQueue(eq EventsQueue[A]) error
 }
 
 // ID is the unique identifier of an aggregate.

--- a/pkg/aggregate/events_test.go
+++ b/pkg/aggregate/events_test.go
@@ -23,21 +23,16 @@ func (e Event) Apply(a Aggregate) error {
 }
 
 func TestNewEventsQueue(t *testing.T) {
-	agg := Aggregate{}
-
 	event1 := Event{ID: 1}
 	event2 := Event{ID: 2}
 
-	es := aggregate.NewEventsQueue(agg)
+	es := aggregate.EventsQueue[Aggregate]{}
 
 	events := es.PopEvents()
 	assert.Len(t, events, 0)
 
-	err := es.PushAndApply(event1)
-	assert.NoError(t, err)
-
-	err = es.PushAndApply(event2)
-	assert.NoError(t, err)
+	es.Record(event1)
+	es.Record(event2)
 
 	events = es.PopEvents()
 	assert.Len(t, events, 2)
@@ -53,8 +48,7 @@ func TestNewEventsQueue(t *testing.T) {
 
 	event3 := Event{ID: 3}
 
-	err = es.PushAndApply(event3)
-	assert.NoError(t, err)
+	es.Record(event3)
 
 	events = es.PopEvents()
 	assert.Len(t, events, 1)

--- a/pkg/repository/inmemory/repository.go
+++ b/pkg/repository/inmemory/repository.go
@@ -30,7 +30,12 @@ func (i *Repository[T]) Load(_ context.Context, id aggregate.ID, target aggregat
 		return repository.ErrAggregateNotFound
 	}
 
-	return target.FromEvents(events)
+	eq, err := aggregate.NewEventsQueueFromEvents(events)
+	if err != nil {
+		return err
+	}
+
+	return target.FromEventsQueue(eq)
 }
 
 func (i *Repository[T]) Save(_ context.Context, a aggregate.Aggregate[T]) error {

--- a/pkg/repository/sql/repository.go
+++ b/pkg/repository/sql/repository.go
@@ -122,7 +122,12 @@ func (r Repository[T]) Load(ctx context.Context, id aggregate.ID, target aggrega
 		return repository.ErrAggregateNotFound
 	}
 
-	return target.FromEvents(events)
+	eq, err := aggregate.NewEventsQueueFromEvents(events)
+	if err != nil {
+		return err
+	}
+
+	return target.FromEventsQueue(eq)
 }
 
 // Save saves the aggregate's queued events to the database.


### PR DESCRIPTION
This approach avoids the weird cross-reference between the queue and the aggregate.
The queue becomes simpler and concerns only about one thing.