### PR TITLE
Refactor Stream/Events generics

### DIFF
--- a/_examples/postcard/postcard.go
+++ b/_examples/postcard/postcard.go
@@ -13,10 +13,8 @@ type Postcard struct {
 
 	sender    Address
 	addressee Address
-
-	content string
-
-	sent bool
+	content   string
+	sent      bool
 }
 
 type Address struct {

--- a/_examples/postcard/postcard.go
+++ b/_examples/postcard/postcard.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Postcard struct {
-	events stream.Events[*Postcard]
+	events *stream.Events[Postcard]
 
 	id string
 
@@ -27,9 +27,11 @@ type Address struct {
 }
 
 func NewPostcard(id string) (*Postcard, error) {
-	p := &Postcard{}
+	p := &Postcard{
+		events: new(stream.Events[Postcard]),
+	}
 
-	err := stream.Record[*Postcard](p, &p.events, Created{
+	err := stream.Record[Postcard](p, Created{
 		ID: id,
 	})
 	if err != nil {
@@ -39,31 +41,31 @@ func NewPostcard(id string) (*Postcard, error) {
 	return p, nil
 }
 
-func (p *Postcard) PopEvents() []stream.VersionedEvent[*Postcard] {
-	return p.events.PopEvents()
+func (p Postcard) StreamID() stream.ID {
+	return stream.ID(p.id)
 }
 
-func (p *Postcard) FromEvents(events stream.Events[*Postcard]) error {
+func (p Postcard) Events() *stream.Events[Postcard] {
+	return p.events
+}
+
+func (p Postcard) WithEvents(events *stream.Events[Postcard]) Postcard {
 	p.events = events
-	return stream.ApplyAll(p)
+	return p
 }
 
 func (p *Postcard) ID() string {
 	return p.id
 }
 
-func (p *Postcard) StreamID() stream.ID {
-	return stream.ID(p.id)
-}
-
 func (p *Postcard) Write(content string) error {
-	return stream.Record[*Postcard](p, &p.events, Written{
+	return stream.Record[Postcard](p, Written{
 		Content: content,
 	})
 }
 
 func (p *Postcard) Address(sender Address, addressee Address) error {
-	return stream.Record[*Postcard](p, &p.events, Addressed{
+	return stream.Record[Postcard](p, Addressed{
 		Sender:    sender,
 		Addressee: addressee,
 	})
@@ -74,7 +76,7 @@ func (p *Postcard) Send() error {
 		return fmt.Errorf("postcard already sent")
 	}
 
-	return stream.Record[*Postcard](p, &p.events, Sent{})
+	return stream.Record[Postcard](p, Sent{})
 }
 
 func (p *Postcard) Sender() Address {

--- a/_examples/postcard/postcard.go
+++ b/_examples/postcard/postcard.go
@@ -49,9 +49,8 @@ func (p Postcard) Events() *stream.Events[Postcard] {
 	return p.events
 }
 
-func (p Postcard) WithEvents(events *stream.Events[Postcard]) Postcard {
-	p.events = events
-	return p
+func (p Postcard) NewFromEvents(events *stream.Events[Postcard]) *Postcard {
+	return &Postcard{events: events}
 }
 
 func (p *Postcard) ID() string {

--- a/_examples/postcard/postcard_test.go
+++ b/_examples/postcard/postcard_test.go
@@ -48,18 +48,15 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal("content", pc.Content())
 
-	eventsSlice := pc.Events().PopEvents()
-	assert.Len(eventsSlice, 3)
+	events := pc.Events().PopEvents()
+	assert.Len(events, 3)
 
 	expectedEvents := []stream.VersionedEvent[postcard.Postcard]{
 		{Event: postcard.Created{ID: id}, StreamVersion: 1},
 		{Event: postcard.Addressed{Sender: senderAddress, Addressee: addresseeAddress}, StreamVersion: 2},
 		{Event: postcard.Written{Content: "content"}, StreamVersion: 3},
 	}
-	assert.Equal(expectedEvents, eventsSlice)
-
-	events, err := stream.NewEvents(eventsSlice)
-	assert.NoError(err)
+	assert.Equal(expectedEvents, events)
 
 	pcLoaded, err := stream.New(events)
 	assert.NoError(err)
@@ -69,11 +66,11 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	assert.Equal("content", pcLoaded.Content())
 	assert.False(pcLoaded.Sent())
 
-	eventsSlice = pc.Events().PopEvents()
-	assert.Len(eventsSlice, 0)
+	events = pc.Events().PopEvents()
+	assert.Len(events, 0)
 
-	eventsSlice = pcLoaded.Events().PopEvents()
-	assert.Len(eventsSlice, 0)
+	events = pcLoaded.Events().PopEvents()
+	assert.Len(events, 0)
 
 	err = pcLoaded.Write("new content")
 	require.NoError(t, err)
@@ -82,13 +79,13 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(pcLoaded.Sent())
 
-	eventsSlice = pcLoaded.Events().PopEvents()
-	assert.Len(eventsSlice, 2)
+	events = pcLoaded.Events().PopEvents()
+	assert.Len(events, 2)
 
 	expectedEvents = []stream.VersionedEvent[postcard.Postcard]{
 		{Event: postcard.Written{Content: "new content"}, StreamVersion: 4},
 		{Event: postcard.Sent{}, StreamVersion: 5},
 	}
 
-	assert.Equal(expectedEvents, eventsSlice)
+	assert.Equal(expectedEvents, events)
 }

--- a/_examples/postcard/postcard_test.go
+++ b/_examples/postcard/postcard_test.go
@@ -48,21 +48,20 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal("content", pc.Content())
 
-	events := pc.Events().PopEvents()
-	assert.Len(events, 3)
+	eventsSlice := pc.Events().PopEvents()
+	assert.Len(eventsSlice, 3)
 
 	expectedEvents := []stream.VersionedEvent[postcard.Postcard]{
 		{Event: postcard.Created{ID: id}, StreamVersion: 1},
 		{Event: postcard.Addressed{Sender: senderAddress, Addressee: addresseeAddress}, StreamVersion: 2},
 		{Event: postcard.Written{Content: "content"}, StreamVersion: 3},
 	}
-	assert.Equal(expectedEvents, events)
+	assert.Equal(expectedEvents, eventsSlice)
 
-	eq := &stream.Events[postcard.Postcard]{}
-	err = eq.LoadEvents(events)
+	events, err := stream.NewEvents(eventsSlice)
 	assert.NoError(err)
 
-	pcLoaded, err := stream.New(eq)
+	pcLoaded, err := stream.New(events)
 	assert.NoError(err)
 
 	assert.Equal(senderAddress, pcLoaded.Sender())
@@ -70,11 +69,11 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	assert.Equal("content", pcLoaded.Content())
 	assert.False(pcLoaded.Sent())
 
-	events = pc.Events().PopEvents()
-	assert.Len(events, 0)
+	eventsSlice = pc.Events().PopEvents()
+	assert.Len(eventsSlice, 0)
 
-	events = pcLoaded.Events().PopEvents()
-	assert.Len(events, 0)
+	eventsSlice = pcLoaded.Events().PopEvents()
+	assert.Len(eventsSlice, 0)
 
 	err = pcLoaded.Write("new content")
 	require.NoError(t, err)
@@ -83,13 +82,13 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(pcLoaded.Sent())
 
-	events = pcLoaded.Events().PopEvents()
-	assert.Len(events, 2)
+	eventsSlice = pcLoaded.Events().PopEvents()
+	assert.Len(eventsSlice, 2)
 
 	expectedEvents = []stream.VersionedEvent[postcard.Postcard]{
 		{Event: postcard.Written{Content: "new content"}, StreamVersion: 4},
 		{Event: postcard.Sent{}, StreamVersion: 5},
 	}
 
-	assert.Equal(expectedEvents, events)
+	assert.Equal(expectedEvents, eventsSlice)
 }

--- a/_examples/postcard/postcard_test.go
+++ b/_examples/postcard/postcard_test.go
@@ -48,21 +48,21 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal("content", pc.Content())
 
-	events := pc.PopEvents()
+	events := pc.Events().PopEvents()
 	assert.Len(events, 3)
 
-	expectedEvents := []stream.VersionedEvent[*postcard.Postcard]{
+	expectedEvents := []stream.VersionedEvent[postcard.Postcard]{
 		{Event: postcard.Created{ID: id}, StreamVersion: 1},
 		{Event: postcard.Addressed{Sender: senderAddress, Addressee: addresseeAddress}, StreamVersion: 2},
 		{Event: postcard.Written{Content: "content"}, StreamVersion: 3},
 	}
 	assert.Equal(expectedEvents, events)
 
-	eq, err := stream.LoadEvents(events)
+	eq := &stream.Events[postcard.Postcard]{}
+	err = eq.PushEvents(events)
 	assert.NoError(err)
 
-	pcLoaded := postcard.Postcard{}
-	err = pcLoaded.FromEvents(eq)
+	pcLoaded, err := stream.New(eq)
 	assert.NoError(err)
 
 	assert.Equal(senderAddress, pcLoaded.Sender())
@@ -70,10 +70,10 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	assert.Equal("content", pcLoaded.Content())
 	assert.False(pcLoaded.Sent())
 
-	events = pc.PopEvents()
+	events = pc.Events().PopEvents()
 	assert.Len(events, 0)
 
-	events = pcLoaded.PopEvents()
+	events = pcLoaded.Events().PopEvents()
 	assert.Len(events, 0)
 
 	err = pcLoaded.Write("new content")
@@ -83,10 +83,10 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(pcLoaded.Sent())
 
-	events = pcLoaded.PopEvents()
+	events = pcLoaded.Events().PopEvents()
 	assert.Len(events, 2)
 
-	expectedEvents = []stream.VersionedEvent[*postcard.Postcard]{
+	expectedEvents = []stream.VersionedEvent[postcard.Postcard]{
 		{Event: postcard.Written{Content: "new content"}, StreamVersion: 4},
 		{Event: postcard.Sent{}, StreamVersion: 5},
 	}

--- a/_examples/postcard/postcard_test.go
+++ b/_examples/postcard/postcard_test.go
@@ -59,7 +59,7 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	assert.Equal(expectedEvents, events)
 
 	eq := &stream.Events[postcard.Postcard]{}
-	err = eq.PushEvents(events)
+	err = eq.LoadEvents(events)
 	assert.NoError(err)
 
 	pcLoaded, err := stream.New(eq)

--- a/_examples/postcard/storage/eventstore_test.go
+++ b/_examples/postcard/storage/eventstore_test.go
@@ -39,15 +39,15 @@ func TestPostcard_Repositories(t *testing.T) {
 
 	testCases := []struct {
 		name       string
-		repository eventstore.EventStore[*postcard.Postcard]
+		repository eventstore.EventStore[postcard.Postcard]
 	}{
 		{
 			name:       "in_memory",
-			repository: eventstore.NewInMemoryStore[*postcard.Postcard](),
+			repository: eventstore.NewInMemoryStore[postcard.Postcard](),
 		},
 		{
 			name: "postgres_simple",
-			repository: func() eventstore.EventStore[*postcard.Postcard] {
+			repository: func() eventstore.EventStore[postcard.Postcard] {
 				repo, err := storage.NewDefaultSimplePostcardRepository(context.Background(), postgresDB)
 				require.NoError(t, err)
 				return repo
@@ -55,7 +55,7 @@ func TestPostcard_Repositories(t *testing.T) {
 		},
 		{
 			name: "postgres_simple_custom",
-			repository: func() eventstore.EventStore[*postcard.Postcard] {
+			repository: func() eventstore.EventStore[postcard.Postcard] {
 				repo, err := storage.NewCustomSimplePostcardRepository(context.Background(), postgresDB)
 				require.NoError(t, err)
 				return repo
@@ -63,7 +63,7 @@ func TestPostcard_Repositories(t *testing.T) {
 		},
 		{
 			name: "postgres_simple_anonymized",
-			repository: func() eventstore.EventStore[*postcard.Postcard] {
+			repository: func() eventstore.EventStore[postcard.Postcard] {
 				repo, err := storage.NewSimpleAnonymizingPostcardRepository(context.Background(), postgresDB)
 				require.NoError(t, err)
 				return repo
@@ -71,7 +71,7 @@ func TestPostcard_Repositories(t *testing.T) {
 		},
 		{
 			name: "postgres_mapping",
-			repository: func() eventstore.EventStore[*postcard.Postcard] {
+			repository: func() eventstore.EventStore[postcard.Postcard] {
 				repo, err := storage.NewDefaultMappingPostgresRepository(context.Background(), postgresDB)
 				require.NoError(t, err)
 				return repo
@@ -79,7 +79,7 @@ func TestPostcard_Repositories(t *testing.T) {
 		},
 		{
 			name: "postgres_mapping_custom",
-			repository: func() eventstore.EventStore[*postcard.Postcard] {
+			repository: func() eventstore.EventStore[postcard.Postcard] {
 				repo, err := storage.NewCustomMappingPostcardRepository(context.Background(), postgresDB)
 				require.NoError(t, err)
 				return repo
@@ -87,7 +87,7 @@ func TestPostcard_Repositories(t *testing.T) {
 		},
 		{
 			name: "postgres_mapping_anonymized",
-			repository: func() eventstore.EventStore[*postcard.Postcard] {
+			repository: func() eventstore.EventStore[postcard.Postcard] {
 				repo, err := storage.NewMappingAnonymizingPostcardRepository(context.Background(), postgresDB)
 				require.NoError(t, err)
 				return repo
@@ -95,7 +95,7 @@ func TestPostcard_Repositories(t *testing.T) {
 		},
 		{
 			name: "sqlite_simple",
-			repository: func() eventstore.EventStore[*postcard.Postcard] {
+			repository: func() eventstore.EventStore[postcard.Postcard] {
 				repo, err := storage.NewSimpleSQLitePostcardRepository(context.Background(), sqliteDB)
 				require.NoError(t, err)
 				return repo
@@ -103,7 +103,7 @@ func TestPostcard_Repositories(t *testing.T) {
 		},
 		{
 			name: "sqlite_mapping",
-			repository: func() eventstore.EventStore[*postcard.Postcard] {
+			repository: func() eventstore.EventStore[postcard.Postcard] {
 				repo, err := storage.NewMappingSQLitePostcardRepository(context.Background(), sqliteDB)
 				require.NoError(t, err)
 				return repo
@@ -128,7 +128,7 @@ func TestPostcard_Repositories(t *testing.T) {
 			_, err = tc.repository.Load(ctx, stream.ID(id))
 			assert.ErrorIs(t, err, eventstore.ErrStreamNotFound, "expected stream not found yet")
 
-			err = tc.repository.Save(ctx, pc)
+			err = tc.repository.Save(ctx, *pc)
 			require.NoError(t, err, "should save the stream and it has some events already")
 
 			fromRepo2, err := tc.repository.Load(ctx, stream.ID(id))
@@ -140,7 +140,7 @@ func TestPostcard_Repositories(t *testing.T) {
 			assert.Equal(t, pc.ID(), fromRepo2.ID())
 			assert.Equal(t, pc.Addressee(), fromRepo2.Addressee())
 			assert.Equal(t, pc.Sender(), fromRepo2.Sender())
-			assert.Empty(t, fromRepo2.PopEvents())
+			assert.Empty(t, fromRepo2.Events().PopEvents())
 
 			err = fromRepo2.Write("content")
 			require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestPostcard_Repositories(t *testing.T) {
 			assert.Equal(t, addresseeAddress, fromRepo3.Addressee())
 			assert.Equal(t, "content", fromRepo3.Content())
 			assert.True(t, fromRepo3.Sent())
-			assert.Empty(t, fromRepo3.PopEvents())
+			assert.Empty(t, fromRepo3.Events().PopEvents())
 		})
 	}
 }

--- a/_examples/postcard/storage/eventstore_test.go
+++ b/_examples/postcard/storage/eventstore_test.go
@@ -128,7 +128,7 @@ func TestPostcard_Repositories(t *testing.T) {
 			_, err = tc.repository.Load(ctx, stream.ID(id))
 			assert.ErrorIs(t, err, eventstore.ErrStreamNotFound, "expected stream not found yet")
 
-			err = tc.repository.Save(ctx, *pc)
+			err = tc.repository.Save(ctx, pc)
 			require.NoError(t, err, "should save the stream and it has some events already")
 
 			fromRepo2, err := tc.repository.Load(ctx, stream.ID(id))

--- a/_examples/postcard/storage/mapping_postgres_eventstore.go
+++ b/_examples/postcard/storage/mapping_postgres_eventstore.go
@@ -11,12 +11,12 @@ import (
 	"postcard"
 )
 
-func NewDefaultMappingPostgresRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[*postcard.Postcard], error) {
-	return eventstore.NewSQLStore[*postcard.Postcard](
+func NewDefaultMappingPostgresRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[postcard.Postcard], error) {
+	return eventstore.NewSQLStore[postcard.Postcard](
 		ctx,
 		db,
-		eventstore.NewMappingPostgresSQLConfig[*postcard.Postcard](
-			[]transport.EventMapper[*postcard.Postcard]{
+		eventstore.NewMappingPostgresSQLConfig[postcard.Postcard](
+			[]transport.EventMapper[postcard.Postcard]{
 				CreatedMapper{},
 				AddressedMapper{},
 				WrittenMapper{},
@@ -26,15 +26,15 @@ func NewDefaultMappingPostgresRepository(ctx context.Context, db *sql.DB) (event
 	)
 }
 
-func NewCustomMappingPostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[*postcard.Postcard], error) {
-	return eventstore.NewSQLStore[*postcard.Postcard](
+func NewCustomMappingPostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[postcard.Postcard], error) {
+	return eventstore.NewSQLStore[postcard.Postcard](
 		ctx,
 		db,
-		eventstore.SQLConfig[*postcard.Postcard]{
-			SchemaAdapter: eventstore.NewPostgresSchemaAdapter[*postcard.Postcard]("PostcardMapping"),
+		eventstore.SQLConfig[postcard.Postcard]{
+			SchemaAdapter: eventstore.NewPostgresSchemaAdapter[postcard.Postcard]("PostcardMapping"),
 			Serializer: transport.NewMappingSerializer(
 				transport.JSONMarshaler{},
-				[]transport.EventMapper[*postcard.Postcard]{
+				[]transport.EventMapper[postcard.Postcard]{
 					CreatedMapper{},
 					AddressedMapper{},
 					WrittenMapper{},
@@ -45,16 +45,16 @@ func NewCustomMappingPostcardRepository(ctx context.Context, db *sql.DB) (events
 	)
 }
 
-func NewMappingAnonymizingPostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[*postcard.Postcard], error) {
-	return eventstore.NewSQLStore[*postcard.Postcard](
+func NewMappingAnonymizingPostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[postcard.Postcard], error) {
+	return eventstore.NewSQLStore[postcard.Postcard](
 		ctx,
 		db,
-		eventstore.SQLConfig[*postcard.Postcard]{
-			SchemaAdapter: eventstore.NewPostgresSchemaAdapter[*postcard.Postcard]("PostcardMappingAnonymizing"),
-			Serializer: transport.NewAESAnonymizingSerializer[*postcard.Postcard](
-				transport.NewMappingSerializer[*postcard.Postcard](
+		eventstore.SQLConfig[postcard.Postcard]{
+			SchemaAdapter: eventstore.NewPostgresSchemaAdapter[postcard.Postcard]("PostcardMappingAnonymizing"),
+			Serializer: transport.NewAESAnonymizingSerializer[postcard.Postcard](
+				transport.NewMappingSerializer[postcard.Postcard](
 					transport.JSONMarshaler{},
-					[]transport.EventMapper[*postcard.Postcard]{
+					[]transport.EventMapper[postcard.Postcard]{
 						CreatedMapper{},
 						AddressedMapper{},
 						WrittenMapper{},
@@ -67,12 +67,12 @@ func NewMappingAnonymizingPostcardRepository(ctx context.Context, db *sql.DB) (e
 	)
 }
 
-func NewMappingSQLitePostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[*postcard.Postcard], error) {
-	return eventstore.NewSQLStore[*postcard.Postcard](
+func NewMappingSQLitePostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[postcard.Postcard], error) {
+	return eventstore.NewSQLStore[postcard.Postcard](
 		ctx,
 		db,
-		eventstore.NewMappingSQLiteConfig[*postcard.Postcard](
-			[]transport.EventMapper[*postcard.Postcard]{
+		eventstore.NewMappingSQLiteConfig[postcard.Postcard](
+			[]transport.EventMapper[postcard.Postcard]{
 				CreatedMapper{},
 				AddressedMapper{},
 				WrittenMapper{},
@@ -88,7 +88,7 @@ type Created struct {
 
 type CreatedMapper struct{}
 
-func (CreatedMapper) SupportedEvent() stream.Event[*postcard.Postcard] {
+func (CreatedMapper) SupportedEvent() stream.Event[postcard.Postcard] {
 	return postcard.Created{}
 }
 
@@ -96,14 +96,14 @@ func (CreatedMapper) StorageEvent() any {
 	return Created{}
 }
 
-func (CreatedMapper) ToStorage(event stream.Event[*postcard.Postcard]) any {
+func (CreatedMapper) ToStorage(event stream.Event[postcard.Postcard]) any {
 	e := event.(postcard.Created)
 	return Created{
 		ID: e.ID,
 	}
 }
 
-func (CreatedMapper) FromStorage(event any) stream.Event[*postcard.Postcard] {
+func (CreatedMapper) FromStorage(event any) stream.Event[postcard.Postcard] {
 	e := event.(Created)
 	return postcard.Created{
 		ID: e.ID,
@@ -117,7 +117,7 @@ type Addressed struct {
 
 type AddressedMapper struct{}
 
-func (AddressedMapper) SupportedEvent() stream.Event[*postcard.Postcard] {
+func (AddressedMapper) SupportedEvent() stream.Event[postcard.Postcard] {
 	return postcard.Addressed{}
 }
 
@@ -125,7 +125,7 @@ func (AddressedMapper) StorageEvent() any {
 	return Addressed{}
 }
 
-func (AddressedMapper) ToStorage(event stream.Event[*postcard.Postcard]) any {
+func (AddressedMapper) ToStorage(event stream.Event[postcard.Postcard]) any {
 	e := event.(postcard.Addressed)
 	return Addressed{
 		Sender:    Address(e.Sender),
@@ -133,7 +133,7 @@ func (AddressedMapper) ToStorage(event stream.Event[*postcard.Postcard]) any {
 	}
 }
 
-func (AddressedMapper) FromStorage(event any) stream.Event[*postcard.Postcard] {
+func (AddressedMapper) FromStorage(event any) stream.Event[postcard.Postcard] {
 	e := event.(Addressed)
 	return postcard.Addressed{
 		Sender:    postcard.Address(e.Sender),
@@ -154,7 +154,7 @@ type Written struct {
 
 type WrittenMapper struct{}
 
-func (WrittenMapper) SupportedEvent() stream.Event[*postcard.Postcard] {
+func (WrittenMapper) SupportedEvent() stream.Event[postcard.Postcard] {
 	return postcard.Written{}
 }
 
@@ -162,14 +162,14 @@ func (WrittenMapper) StorageEvent() any {
 	return Written{}
 }
 
-func (WrittenMapper) ToStorage(e stream.Event[*postcard.Postcard]) any {
+func (WrittenMapper) ToStorage(e stream.Event[postcard.Postcard]) any {
 	ev := e.(postcard.Written)
 	return Written{
 		Content: ev.Content,
 	}
 }
 
-func (WrittenMapper) FromStorage(event any) stream.Event[*postcard.Postcard] {
+func (WrittenMapper) FromStorage(event any) stream.Event[postcard.Postcard] {
 	e := event.(Written)
 	return postcard.Written{
 		Content: e.Content,
@@ -180,7 +180,7 @@ type Sent struct{}
 
 type SentMapper struct{}
 
-func (SentMapper) SupportedEvent() stream.Event[*postcard.Postcard] {
+func (SentMapper) SupportedEvent() stream.Event[postcard.Postcard] {
 	return postcard.Sent{}
 }
 
@@ -188,10 +188,10 @@ func (SentMapper) StorageEvent() any {
 	return Sent{}
 }
 
-func (SentMapper) ToStorage(event stream.Event[*postcard.Postcard]) any {
+func (SentMapper) ToStorage(event stream.Event[postcard.Postcard]) any {
 	return Sent{}
 }
 
-func (SentMapper) FromStorage(event any) stream.Event[*postcard.Postcard] {
+func (SentMapper) FromStorage(event any) stream.Event[postcard.Postcard] {
 	return postcard.Sent{}
 }

--- a/_examples/postcard/storage/simple_postgres_eventstore.go
+++ b/_examples/postcard/storage/simple_postgres_eventstore.go
@@ -13,12 +13,12 @@ import (
 	"postcard"
 )
 
-func NewDefaultSimplePostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[*postcard.Postcard], error) {
-	return eventstore.NewSQLStore[*postcard.Postcard](
+func NewDefaultSimplePostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[postcard.Postcard], error) {
+	return eventstore.NewSQLStore[postcard.Postcard](
 		ctx,
 		db,
-		eventstore.NewPostgresSQLConfig[*postcard.Postcard](
-			[]stream.Event[*postcard.Postcard]{
+		eventstore.NewPostgresSQLConfig[postcard.Postcard](
+			[]stream.Event[postcard.Postcard]{
 				postcard.Created{},
 				postcard.Addressed{},
 				postcard.Written{},
@@ -28,15 +28,15 @@ func NewDefaultSimplePostcardRepository(ctx context.Context, db *sql.DB) (events
 	)
 }
 
-func NewCustomSimplePostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[*postcard.Postcard], error) {
-	return eventstore.NewSQLStore[*postcard.Postcard](
+func NewCustomSimplePostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[postcard.Postcard], error) {
+	return eventstore.NewSQLStore[postcard.Postcard](
 		ctx,
 		db,
-		eventstore.SQLConfig[*postcard.Postcard]{
-			SchemaAdapter: eventstore.NewPostgresSchemaAdapter[*postcard.Postcard]("PostcardSimple"),
+		eventstore.SQLConfig[postcard.Postcard]{
+			SchemaAdapter: eventstore.NewPostgresSchemaAdapter[postcard.Postcard]("PostcardSimple"),
 			Serializer: transport.NewSimpleSerializer(
 				transport.JSONMarshaler{},
-				[]stream.Event[*postcard.Postcard]{
+				[]stream.Event[postcard.Postcard]{
 					postcard.Created{},
 					postcard.Addressed{},
 					postcard.Written{},
@@ -47,16 +47,16 @@ func NewCustomSimplePostcardRepository(ctx context.Context, db *sql.DB) (eventst
 	)
 }
 
-func NewSimpleAnonymizingPostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[*postcard.Postcard], error) {
-	return eventstore.NewSQLStore[*postcard.Postcard](
+func NewSimpleAnonymizingPostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[postcard.Postcard], error) {
+	return eventstore.NewSQLStore[postcard.Postcard](
 		ctx,
 		db,
-		eventstore.SQLConfig[*postcard.Postcard]{
-			SchemaAdapter: eventstore.NewPostgresSchemaAdapter[*postcard.Postcard]("PostcardSimpleAnonymizing"),
-			Serializer: transport.NewAESAnonymizingSerializer[*postcard.Postcard](
-				transport.NewSimpleSerializer[*postcard.Postcard](
+		eventstore.SQLConfig[postcard.Postcard]{
+			SchemaAdapter: eventstore.NewPostgresSchemaAdapter[postcard.Postcard]("PostcardSimpleAnonymizing"),
+			Serializer: transport.NewAESAnonymizingSerializer[postcard.Postcard](
+				transport.NewSimpleSerializer[postcard.Postcard](
 					transport.JSONMarshaler{},
-					[]stream.Event[*postcard.Postcard]{
+					[]stream.Event[postcard.Postcard]{
 						postcard.Created{},
 						postcard.Addressed{},
 						postcard.Written{},
@@ -69,12 +69,12 @@ func NewSimpleAnonymizingPostcardRepository(ctx context.Context, db *sql.DB) (ev
 	)
 }
 
-func NewSimpleSQLitePostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[*postcard.Postcard], error) {
-	return eventstore.NewSQLStore[*postcard.Postcard](
+func NewSimpleSQLitePostcardRepository(ctx context.Context, db *sql.DB) (eventstore.EventStore[postcard.Postcard], error) {
+	return eventstore.NewSQLStore[postcard.Postcard](
 		ctx,
 		db,
-		eventstore.NewSQLiteConfig[*postcard.Postcard](
-			[]stream.Event[*postcard.Postcard]{
+		eventstore.NewSQLiteConfig[postcard.Postcard](
+			[]stream.Event[postcard.Postcard]{
 				postcard.Created{},
 				postcard.Addressed{},
 				postcard.Written{},

--- a/eventstore/eventstore.go
+++ b/eventstore/eventstore.go
@@ -18,5 +18,5 @@ var (
 // 2. Save would call `PopEvents()` and then save them under the stream's id from `StreamID()`.
 type EventStore[T stream.Stream[T]] interface {
 	Load(ctx context.Context, id stream.ID) (*T, error)
-	Save(ctx context.Context, stream T) error
+	Save(ctx context.Context, stream *T) error
 }

--- a/eventstore/eventstore.go
+++ b/eventstore/eventstore.go
@@ -14,9 +14,9 @@ var (
 // EventStore loads and saves T implementing stream.Stream
 //
 // An example implementation of EventStore:
-// 1. Load would fetch all events for `StreamID()` and use them to instantiate a `T` using `FromEvents()` and return it.
+// 1. Load would fetch all events for `StreamID()` and use them to instantiate a pointer to `T` using `FromEvents()` and return it.
 // 2. Save would call `PopEvents()` and then save them under the stream's id from `StreamID()`.
 type EventStore[T stream.Stream[T]] interface {
-	Load(ctx context.Context, id stream.ID) (T, error)
+	Load(ctx context.Context, id stream.ID) (*T, error)
 	Save(ctx context.Context, stream T) error
 }

--- a/eventstore/eventstore.go
+++ b/eventstore/eventstore.go
@@ -12,11 +12,12 @@ var (
 )
 
 // EventStore loads and saves T implementing stream.Stream
-//
-// An example implementation of EventStore:
-// 1. Load would fetch all events for `StreamID()` and use them to instantiate a pointer to `T` using `FromEvents()` and return it.
-// 2. Save would call `PopEvents()` and then save them under the stream's id from `StreamID()`.
 type EventStore[T stream.Stream[T]] interface {
+	// Load will fetch all events for `StreamID()` and use them
+	// to instantiate a pointer to `T` using `FromEvents()` and return it.
 	Load(ctx context.Context, id stream.ID) (*T, error)
+
+	// Save will call `PopEvents()` and then save them
+	// under the stream's id from `StreamID()`.
 	Save(ctx context.Context, stream *T) error
 }

--- a/eventstore/inmemory.go
+++ b/eventstore/inmemory.go
@@ -20,15 +20,13 @@ func NewInMemoryStore[T stream.Stream[T]]() *InMemoryStore[T] {
 	}
 }
 
-func (i *InMemoryStore[T]) Load(_ context.Context, id stream.ID) (T, error) {
+func (i *InMemoryStore[T]) Load(_ context.Context, id stream.ID) (*T, error) {
 	i.lock.RLock()
 	defer i.lock.RUnlock()
 
-	var t T
-
 	events, ok := i.events[id]
 	if !ok {
-		return t, ErrStreamNotFound
+		return nil, ErrStreamNotFound
 	}
 
 	return stream.New(events)

--- a/eventstore/inmemory.go
+++ b/eventstore/inmemory.go
@@ -26,18 +26,17 @@ func (i *InMemoryStore[T]) Load(_ context.Context, id stream.ID) (T, error) {
 
 	var t T
 
-	events, ok := i.events[id]
+	eventsSlice, ok := i.events[id]
 	if !ok {
 		return t, ErrStreamNotFound
 	}
 
-	eq := &stream.Events[T]{}
-	err := eq.LoadEvents(events)
+	events, err := stream.NewEvents(eventsSlice)
 	if err != nil {
 		return t, err
 	}
 
-	return stream.New(eq)
+	return stream.New(events)
 }
 
 func (i *InMemoryStore[T]) Save(_ context.Context, a T) error {

--- a/eventstore/inmemory.go
+++ b/eventstore/inmemory.go
@@ -32,7 +32,7 @@ func (i *InMemoryStore[T]) Load(_ context.Context, id stream.ID) (T, error) {
 	}
 
 	eq := &stream.Events[T]{}
-	err := eq.PushEvents(events)
+	err := eq.LoadEvents(events)
 	if err != nil {
 		return t, err
 	}

--- a/eventstore/inmemory.go
+++ b/eventstore/inmemory.go
@@ -26,14 +26,9 @@ func (i *InMemoryStore[T]) Load(_ context.Context, id stream.ID) (T, error) {
 
 	var t T
 
-	eventsSlice, ok := i.events[id]
+	events, ok := i.events[id]
 	if !ok {
 		return t, ErrStreamNotFound
-	}
-
-	events, err := stream.NewEvents(eventsSlice)
-	if err != nil {
-		return t, err
 	}
 
 	return stream.New(events)

--- a/eventstore/sql.go
+++ b/eventstore/sql.go
@@ -119,7 +119,7 @@ func (s SQLStore[T]) Load(ctx context.Context, id stream.ID) (T, error) {
 	}
 
 	eq := &stream.Events[T]{}
-	err = eq.PushEvents(events)
+	err = eq.LoadEvents(events)
 	if err != nil {
 		return t, err
 	}

--- a/eventstore/sql.go
+++ b/eventstore/sql.go
@@ -121,7 +121,13 @@ func (s SQLStore[T]) Load(ctx context.Context, id stream.ID) (*T, error) {
 }
 
 // Save saves the stream's queued events to the database.
-func (s SQLStore[T]) Save(ctx context.Context, stm T) (err error) {
+func (s SQLStore[T]) Save(ctx context.Context, t *T) (err error) {
+	if t == nil {
+		return errors.New("target to save must not be nil")
+	}
+
+	stm := *t
+
 	events := stm.Events().PopEvents()
 	if len(events) == 0 {
 		return errors.New("no events to save")

--- a/eventstore/sql.go
+++ b/eventstore/sql.go
@@ -94,7 +94,7 @@ func (s SQLStore[T]) Load(ctx context.Context, id stream.ID) (T, error) {
 		streamVersion int
 		eventName     stream.EventName
 		eventPayload  []byte
-		eventsSlice   []stream.VersionedEvent[T]
+		events        []stream.VersionedEvent[T]
 	)
 	for results.Next() {
 		err = results.Scan(&streamID, &streamVersion, &eventName, &eventPayload)
@@ -111,16 +111,11 @@ func (s SQLStore[T]) Load(ctx context.Context, id stream.ID) (T, error) {
 			Event:         event,
 			StreamVersion: streamVersion,
 		}
-		eventsSlice = append(eventsSlice, versionedEvent)
+		events = append(events, versionedEvent)
 	}
 
-	if len(eventsSlice) == 0 {
+	if len(events) == 0 {
 		return t, ErrStreamNotFound
-	}
-
-	events, err := stream.NewEvents(eventsSlice)
-	if err != nil {
-		return t, err
 	}
 
 	return stream.New(events)

--- a/eventstore/sql.go
+++ b/eventstore/sql.go
@@ -127,7 +127,7 @@ func (s SQLStore[T]) Load(ctx context.Context, id stream.ID) (T, error) {
 	return stream.New(eq)
 }
 
-// Save saves the streams' queued events to the database.
+// Save saves the stream's queued events to the database.
 func (s SQLStore[T]) Save(ctx context.Context, stm T) (err error) {
 	events := stm.Events().PopEvents()
 	if len(events) == 0 {

--- a/stream/events.go
+++ b/stream/events.go
@@ -31,6 +31,15 @@ type Events[A any] struct {
 	queue   []VersionedEvent[A]
 }
 
+// Record puts a new Event on the queue with proper version.
+func (e *Events[A]) Record(event Event[A]) {
+	e.version += 1
+	e.queue = append(e.queue, VersionedEvent[A]{
+		Event:         event,
+		StreamVersion: e.version,
+	})
+}
+
 // PopEvents returns the events on the queue and clears it.
 func (e *Events[A]) PopEvents() []VersionedEvent[A] {
 	var tmp = make([]VersionedEvent[A], len(e.queue))
@@ -55,12 +64,4 @@ func newEvents[A any](events []VersionedEvent[A]) (*Events[A], error) {
 	e.queue = events
 
 	return e, nil
-}
-
-func (e *Events[A]) record(event Event[A]) {
-	e.version += 1
-	e.queue = append(e.queue, VersionedEvent[A]{
-		Event:         event,
-		StreamVersion: e.version,
-	})
 }

--- a/stream/events.go
+++ b/stream/events.go
@@ -40,6 +40,11 @@ func (e *Events[A]) PopEvents() []VersionedEvent[A] {
 	return tmp
 }
 
+// HasEvents returns true if there are any queued events.
+func (e *Events[A]) HasEvents() bool {
+	return len(e.queue) > 0
+}
+
 func newEvents[A any](events []VersionedEvent[A]) (*Events[A], error) {
 	if len(events) == 0 {
 		return nil, fmt.Errorf("no events to load")
@@ -58,18 +63,4 @@ func (e *Events[A]) record(event Event[A]) {
 		Event:         event,
 		StreamVersion: e.version,
 	})
-}
-
-// PopEvents returns the events on the queue and clears it.
-func (e *Events[A]) PopEvents() []VersionedEvent[A] {
-	var tmp = make([]VersionedEvent[A], len(e.queue))
-	copy(tmp, e.queue)
-	e.queue = []VersionedEvent[A]{}
-
-	return tmp
-}
-
-// HasEvents returns true if there are any queued events.
-func (e *Events[A]) HasEvents() bool {
-	return len(e.queue) > 0
 }

--- a/stream/events.go
+++ b/stream/events.go
@@ -40,8 +40,8 @@ func (e *Events[A]) Record(event Event[A]) {
 	})
 }
 
-// PushEvents loads a set Events with version set to the last event's version.
-func (e *Events[A]) PushEvents(events []VersionedEvent[A]) error {
+// LoadEvents loads a set Events with version set to the last event's version.
+func (e *Events[A]) LoadEvents(events []VersionedEvent[A]) error {
 	if len(events) == 0 {
 		return fmt.Errorf("no events to load")
 	}

--- a/stream/events.go
+++ b/stream/events.go
@@ -31,6 +31,15 @@ type Events[A any] struct {
 	queue   []VersionedEvent[A]
 }
 
+// PopEvents returns the events on the queue and clears it.
+func (e *Events[A]) PopEvents() []VersionedEvent[A] {
+	var tmp = make([]VersionedEvent[A], len(e.queue))
+	copy(tmp, e.queue)
+	e.queue = []VersionedEvent[A]{}
+
+	return tmp
+}
+
 func newEvents[A any](events []VersionedEvent[A]) (*Events[A], error) {
 	if len(events) == 0 {
 		return nil, fmt.Errorf("no events to load")
@@ -43,20 +52,10 @@ func newEvents[A any](events []VersionedEvent[A]) (*Events[A], error) {
 	return e, nil
 }
 
-// Record puts a new Event on the queue with proper version.
-func (e *Events[A]) Record(event Event[A]) {
+func (e *Events[A]) record(event Event[A]) {
 	e.version += 1
 	e.queue = append(e.queue, VersionedEvent[A]{
 		Event:         event,
 		StreamVersion: e.version,
 	})
-}
-
-// PopEvents returns the events on the queue and clears it.
-func (e *Events[A]) PopEvents() []VersionedEvent[A] {
-	var tmp = make([]VersionedEvent[A], len(e.queue))
-	copy(tmp, e.queue)
-	e.queue = []VersionedEvent[A]{}
-
-	return tmp
 }

--- a/stream/events.go
+++ b/stream/events.go
@@ -31,18 +31,7 @@ type Events[A any] struct {
 	queue   []VersionedEvent[A]
 }
 
-// Record puts a new Event on the queue with proper version.
-func (e *Events[A]) Record(event Event[A]) {
-	e.version += 1
-	e.queue = append(e.queue, VersionedEvent[A]{
-		Event:         event,
-		StreamVersion: e.version,
-	})
-}
-
-// NewEvents creates a new instance of Events with set of Events loaded
-// and version set to the last event's version.
-func NewEvents[A any](events []VersionedEvent[A]) (*Events[A], error) {
+func newEvents[A any](events []VersionedEvent[A]) (*Events[A], error) {
 	if len(events) == 0 {
 		return nil, fmt.Errorf("no events to load")
 	}
@@ -52,6 +41,15 @@ func NewEvents[A any](events []VersionedEvent[A]) (*Events[A], error) {
 	e.queue = events
 
 	return e, nil
+}
+
+// Record puts a new Event on the queue with proper version.
+func (e *Events[A]) Record(event Event[A]) {
+	e.version += 1
+	e.queue = append(e.queue, VersionedEvent[A]{
+		Event:         event,
+		StreamVersion: e.version,
+	})
 }
 
 // PopEvents returns the events on the queue and clears it.

--- a/stream/events.go
+++ b/stream/events.go
@@ -40,16 +40,18 @@ func (e *Events[A]) Record(event Event[A]) {
 	})
 }
 
-// LoadEvents loads a set Events with version set to the last event's version.
-func (e *Events[A]) LoadEvents(events []VersionedEvent[A]) error {
+// NewEvents creates a new instance of Events with set of Events loaded
+// and version set to the last event's version.
+func NewEvents[A any](events []VersionedEvent[A]) (*Events[A], error) {
 	if len(events) == 0 {
-		return fmt.Errorf("no events to load")
+		return nil, fmt.Errorf("no events to load")
 	}
 
+	e := new(Events[A])
 	e.version = events[len(events)-1].StreamVersion
 	e.queue = events
 
-	return nil
+	return e, nil
 }
 
 // PopEvents returns the events on the queue and clears it.

--- a/stream/events_test.go
+++ b/stream/events_test.go
@@ -20,9 +20,8 @@ func (s Stream) Events() *stream.Events[Stream] {
 	return s.events
 }
 
-func (s Stream) WithEvents(events *stream.Events[Stream]) Stream {
-	s.events = events
-	return s
+func (s Stream) NewFromEvents(events *stream.Events[Stream]) *Stream {
+	return &Stream{events: events}
 }
 
 type Event struct {

--- a/stream/events_test.go
+++ b/stream/events_test.go
@@ -18,7 +18,7 @@ func (e Event) EventName() stream.EventName {
 	return "Event"
 }
 
-func (e Event) ApplyTo(a Stream) error {
+func (e Event) ApplyTo(a *Stream) error {
 	return nil
 }
 

--- a/stream/events_test.go
+++ b/stream/events_test.go
@@ -38,8 +38,8 @@ func (e Event) ApplyTo(_ *Stream) error {
 }
 
 func TestNewEventsQueue(t *testing.T) {
-	event1 := Event{ID: 1}
-	event2 := Event{ID: 2}
+	var event1 stream.Event[Stream] = Event{ID: 1}
+	var event2 stream.Event[Stream] = Event{ID: 2}
 
 	es := new(stream.Events[Stream])
 	s := Stream{
@@ -71,7 +71,8 @@ func TestNewEventsQueue(t *testing.T) {
 	events = es.PopEvents()
 	assert.Len(t, events, 0)
 
-	event3 := Event{ID: 3}
+	var event3 stream.Event[Stream] = Event{ID: 3}
+
 	err = stream.Record(&s, event3)
 	assert.NoError(t, err)
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -53,12 +53,12 @@ func Record[T Stream[T]](stream *T, e Event[T]) error {
 	return nil
 }
 
-func New[T Stream[T]](eventsSlice []VersionedEvent[T]) (T, error) {
+func New[T Stream[T]](eventsSlice []VersionedEvent[T]) (*T, error) {
 	var t T
 
 	events, err := newEvents(eventsSlice)
 	if err != nil {
-		return t, err
+		return nil, err
 	}
 
 	eventsSlice = events.PopEvents()
@@ -67,9 +67,9 @@ func New[T Stream[T]](eventsSlice []VersionedEvent[T]) (T, error) {
 	for _, e := range eventsSlice {
 		err := e.ApplyTo(target)
 		if err != nil {
-			return t, err
+			return nil, err
 		}
 	}
 
-	return *target, nil
+	return target, nil
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -48,7 +48,7 @@ func Record[T Stream[T]](stream *T, e Event[T]) error {
 		return err
 	}
 
-	(*stream).Events().record(e)
+	(*stream).Events().Record(e)
 
 	return nil
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -4,36 +4,36 @@ package stream
 // In DDD terms, it is the "aggregate root".
 //
 // In order for your domain type to implement Stream:
-//   * Embed Events
-//   * Implement `StreamID` returning a unique identifier (usually the same as your stream's internal ID).
-//   * Implement `PopEvents` that returns the events on the Events.
-//   * Implement `FromEvents` to apply events to your stream.
+//   - Embed pointer to Events queue.
+//   - Implement `StreamID` returning a unique identifier (usually the same as your stream's internal ID).
+//   - Implement `Events` to expose the Events queue.
+//   - Implement `WithEvents` that returns a new instance with the provided Events queue set.
 //
 // Then an EventStore will be able to store and load it.
 //
 // Example:
 //
-//     type User struct {
-//         events stream.Events[*User]
-//         id string
-//     }
+//	type User struct {
+//	    events *stream.Events[User]
+//	    id string
+//	}
 //
-//     func (u *User) StreamID() stream.ID {
-//         return stream.ID(u.id)
-//     }
+//	func (u User) StreamID() stream.ID {
+//	    return stream.ID(u.id)
+//	}
 //
-//     func (u *User) PopEvents() []stream.VersionedEvent[*User] {
-//         return u.events.PopEvents()
-//     }
+//	func (u User) Events() *stream.Events[User] {
+//	    return u.events
+//	}
 //
-//     func (u *User) FromEvents(events stream.Events[*User]) error {
-//         p.events = events
-//         return stream.ApplyAll(p)
-//     }
+//	func (u User) WithEvents(events *stream.Events[User]) User {
+//	    u.events = events
+//		return u
+//	}
 type Stream[T any] interface {
 	StreamID() ID
-	PopEvents() []VersionedEvent[T]
-	FromEvents(eq Events[T]) error
+	Events() *Events[T]
+	WithEvents(events *Events[T]) T
 }
 
 // ID is the unique identifier of a stream.
@@ -43,24 +43,27 @@ func (i ID) String() string {
 	return string(i)
 }
 
-func Record[T any](stream T, events *Events[T], e Event[T]) error {
+func Record[T Stream[T]](stream *T, e Event[T]) error {
 	err := e.ApplyTo(stream)
 	if err != nil {
 		return err
 	}
 
-	events.Record(e)
+	(*stream).Events().Record(e)
 
 	return nil
 }
 
-func ApplyAll[T Stream[T]](stream T) error {
-	for _, e := range stream.PopEvents() {
-		err := e.ApplyTo(stream)
+func New[T Stream[T]](eq *Events[T]) (T, error) {
+	events := eq.PopEvents()
+
+	var t T
+	for _, e := range events {
+		err := e.ApplyTo(&t)
 		if err != nil {
-			return err
+			return t, err
 		}
 	}
 
-	return nil
+	return t.WithEvents(eq), nil
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -54,16 +54,21 @@ func Record[T Stream[T]](stream *T, e Event[T]) error {
 	return nil
 }
 
-func New[T Stream[T]](eq *Events[T]) (T, error) {
-	events := eq.PopEvents()
-
+func New[T Stream[T]](eventsSlice []VersionedEvent[T]) (T, error) {
 	var t T
-	for _, e := range events {
+
+	events, err := newEvents(eventsSlice)
+	if err != nil {
+		return t, err
+	}
+
+	eventsSlice = events.PopEvents()
+	for _, e := range eventsSlice {
 		err := e.ApplyTo(&t)
 		if err != nil {
 			return t, err
 		}
 	}
 
-	return t.WithEvents(eq), nil
+	return t.WithEvents(events), nil
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -49,7 +49,7 @@ func Record[T Stream[T]](stream *T, e Event[T]) error {
 		return err
 	}
 
-	(*stream).Events().Record(e)
+	(*stream).Events().record(e)
 
 	return nil
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -5,9 +5,7 @@ package stream
 //
 // In order for your domain type to implement Stream:
 //   - Embed pointer to Events queue.
-//   - Implement `StreamID` returning a unique identifier (usually the same as your stream's internal ID).
-//   - Implement `Events` to expose the Events queue.
-//   - Implement `WithEvents` that returns a new instance with the provided Events queue set.
+//   - Implement the interface methods in accordance with its description.
 //
 // Then an EventStore will be able to store and load it.
 //
@@ -30,8 +28,13 @@ package stream
 //		return &User{events: events}
 //	}
 type Stream[T any] interface {
+	// StreamID returns a unique identifier (usually the same as your stream's internal ID).
 	StreamID() ID
+
+	// Events exposes a pointer to the Events queue.
 	Events() *Events[T]
+
+	// NewFromEvents returns a new instance with the provided Events queue.
 	NewFromEvents(events *Events[T]) *T
 }
 
@@ -42,6 +45,7 @@ func (i ID) String() string {
 	return string(i)
 }
 
+// Record applies a provided Event and puts that into the stream's internal Events queue.
 func Record[T Stream[T]](stream *T, e Event[T]) error {
 	err := e.ApplyTo(stream)
 	if err != nil {
@@ -53,6 +57,9 @@ func Record[T Stream[T]](stream *T, e Event[T]) error {
 	return nil
 }
 
+// New instantiates a new T with all Events applied to it.
+// At the same time the stream's internal Events queue is initialised,
+// so it can record new upcoming events.
 func New[T Stream[T]](eventsSlice []VersionedEvent[T]) (*T, error) {
 	var t T
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -57,7 +57,7 @@ func Record[T Stream[T]](stream *T, e Event[T]) error {
 	return nil
 }
 
-// New instantiates a new T with all Events applied to it.
+// New instantiates a new T with all events applied to it.
 // At the same time the stream's internal Events queue is initialised,
 // so it can record new upcoming events.
 func New[T Stream[T]](eventsSlice []VersionedEvent[T]) (*T, error) {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -26,14 +26,13 @@ package stream
 //	    return u.events
 //	}
 //
-//	func (u User) WithEvents(events *stream.Events[User]) User {
-//	    u.events = events
-//		return u
+//	func (u User) NewFromEvents(events *stream.Events[User]) *User {
+//		return &User{events: events}
 //	}
 type Stream[T any] interface {
 	StreamID() ID
 	Events() *Events[T]
-	WithEvents(events *Events[T]) T
+	NewFromEvents(events *Events[T]) *T
 }
 
 // ID is the unique identifier of a stream.
@@ -63,12 +62,14 @@ func New[T Stream[T]](eventsSlice []VersionedEvent[T]) (T, error) {
 	}
 
 	eventsSlice = events.PopEvents()
+
+	target := t.NewFromEvents(events)
 	for _, e := range eventsSlice {
-		err := e.ApplyTo(&t)
+		err := e.ApplyTo(target)
 		if err != nil {
 			return t, err
 		}
 	}
 
-	return t.WithEvents(events), nil
+	return *target, nil
 }


### PR DESCRIPTION
Here is the PoC for a little bit of changed implementation of Stream/Events relation.

What I wanted to achieve:
- Allow library users to use the straightforward genetic type definition `Stream[Foo] / Events[Foo]` instead of `Stream[*Foo]`, and use pointers to the generic type only when it is necessary.
- Hide the complexity and API of library internals like `PopChanges`, `Load...` etc., and do not require the user to know how to implement that properly.
- Simplify the reflection-based logic and stream instantiation. Now we have a pretty convenient `stream.New[T](eq Events[T]) T`
- Simplify public library functions. Now we have: `stream.Record[T](*T, e Event[T]) error`

