### PR TITLE
Separate events loading from processing in SQL repository

### DIFF
--- a/_examples/postcard/go.mod
+++ b/_examples/postcard/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 require (
-	github.com/ThreeDotsLabs/pii v0.0.0-20221221144555-f2186024b30d // indirect
+	github.com/ThreeDotsLabs/pii v0.0.0-20230103125711-e0908da9a963 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/_examples/postcard/go.sum
+++ b/_examples/postcard/go.sum
@@ -1,5 +1,7 @@
 github.com/ThreeDotsLabs/pii v0.0.0-20221221144555-f2186024b30d h1:bZBc4vDne17OYqoeSceaq5eaZM6vOUMVaJIBy+dNRH4=
 github.com/ThreeDotsLabs/pii v0.0.0-20221221144555-f2186024b30d/go.mod h1:wu5cEZEjFUIXR9hdniDvGbbZARrYHTRi6G2bNaSCC/E=
+github.com/ThreeDotsLabs/pii v0.0.0-20230103125711-e0908da9a963 h1:4EQlsCpfwxjn5ijR8fdL6ap1q04guWUCHgnZ+jPdEjY=
+github.com/ThreeDotsLabs/pii v0.0.0-20230103125711-e0908da9a963/go.mod h1:wu5cEZEjFUIXR9hdniDvGbbZARrYHTRi6G2bNaSCC/E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/_examples/postcard/storage/simple_postgres_eventstore.go
+++ b/_examples/postcard/storage/simple_postgres_eventstore.go
@@ -108,7 +108,7 @@ func NewGOBSQLitePostcardRepository(ctx context.Context, db *sql.DB) (eventstore
 
 type ConstantSecretProvider struct{}
 
-func (c ConstantSecretProvider) SecretForKey(streamID stream.ID) ([]byte, error) {
+func (c ConstantSecretProvider) SecretForKey(_ context.Context, streamID stream.ID) ([]byte, error) {
 	h, err := hex.DecodeString(strings.ReplaceAll(streamID.String(), "-", ""))
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/ThreeDotsLabs/esja
 
 go 1.18
 
-require (
-	github.com/ThreeDotsLabs/pii v0.0.0-20221221144555-f2186024b30d
-	github.com/stretchr/testify v1.8.1
-)
+require github.com/stretchr/testify v1.8.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/ThreeDotsLabs/pii v0.0.0-20221221144555-f2186024b30d h1:bZBc4vDne17OYqoeSceaq5eaZM6vOUMVaJIBy+dNRH4=
-github.com/ThreeDotsLabs/pii v0.0.0-20221221144555-f2186024b30d/go.mod h1:wu5cEZEjFUIXR9hdniDvGbbZARrYHTRi6G2bNaSCC/E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/transport/anonymizer.go
+++ b/transport/anonymizer.go
@@ -1,6 +1,8 @@
 package transport
 
 import (
+	"context"
+
 	"github.com/ThreeDotsLabs/esja/stream"
 )
 
@@ -8,11 +10,11 @@ import (
 type StructAnonymizer interface {
 	// Anonymize encrypts struct properties using secrets
 	// correlated with a provided stream.ID.
-	Anonymize(key stream.ID, data any) (any, error)
+	Anonymize(ctx context.Context, key stream.ID, data any) (any, error)
 
 	// Deanonymize decrypts struct properties using secrets
 	// correlated with a provided stream.ID.
-	Deanonymize(key stream.ID, data any) (any, error)
+	Deanonymize(ctx context.Context, key stream.ID, data any) (any, error)
 }
 
 // Anonymizer is a wrapper to any transport.Mapper instance.
@@ -39,15 +41,16 @@ func (a *Anonymizer[T]) New(name stream.EventName) (any, error) {
 }
 
 func (a *Anonymizer[T]) FromTransport(
+	ctx context.Context,
 	streamID stream.ID,
 	payload any,
 ) (stream.Event[T], error) {
-	payload, err := a.anonymizer.Deanonymize(streamID, payload)
+	payload, err := a.anonymizer.Deanonymize(ctx, streamID, payload)
 	if err != nil {
 		return nil, err
 	}
 
-	event, err := a.mapper.FromTransport(streamID, payload)
+	event, err := a.mapper.FromTransport(ctx, streamID, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -56,15 +59,16 @@ func (a *Anonymizer[T]) FromTransport(
 }
 
 func (a *Anonymizer[T]) ToTransport(
+	ctx context.Context,
 	streamID stream.ID,
 	event stream.Event[T],
 ) (any, error) {
-	e, err := a.mapper.ToTransport(streamID, event)
+	e, err := a.mapper.ToTransport(ctx, streamID, event)
 	if err != nil {
 		return nil, err
 	}
 
-	payload, err := a.anonymizer.Anonymize(streamID, e)
+	payload, err := a.anonymizer.Anonymize(ctx, streamID, e)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/default_mapper.go
+++ b/transport/default_mapper.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -45,6 +46,7 @@ func (m DefaultMapper[T]) New(name stream.EventName) (any, error) {
 }
 
 func (m DefaultMapper[T]) ToTransport(
+	_ context.Context,
 	_ stream.ID,
 	event stream.Event[T],
 ) (any, error) {
@@ -60,6 +62,7 @@ func (m DefaultMapper[T]) ToTransport(
 }
 
 func (m DefaultMapper[T]) FromTransport(
+	_ context.Context,
 	_ stream.ID,
 	i any,
 ) (stream.Event[T], error) {

--- a/transport/mapper.go
+++ b/transport/mapper.go
@@ -1,6 +1,10 @@
 package transport
 
-import "github.com/ThreeDotsLabs/esja/stream"
+import (
+	"context"
+
+	"github.com/ThreeDotsLabs/esja/stream"
+)
 
 // Mapper translates the event into a serializable transport model.
 type Mapper[T any] interface {
@@ -10,15 +14,9 @@ type Mapper[T any] interface {
 
 	// FromTransport maps corresponding transport model
 	// into an instance of a stream.Event.
-	FromTransport(
-		stream.ID,
-		any,
-	) (stream.Event[T], error)
+	FromTransport(context.Context, stream.ID, any) (stream.Event[T], error)
 
 	// ToTransport maps a stream.Event into an instance of
 	// a corresponding transport model.
-	ToTransport(
-		stream.ID,
-		stream.Event[T],
-	) (any, error)
+	ToTransport(context.Context, stream.ID, stream.Event[T]) (any, error)
 }

--- a/transport/noop_mapper.go
+++ b/transport/noop_mapper.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -37,6 +38,7 @@ func (m NoOpMapper[T]) New(name stream.EventName) (any, error) {
 }
 
 func (m NoOpMapper[T]) ToTransport(
+	_ context.Context,
 	_ stream.ID,
 	event stream.Event[T],
 ) (any, error) {
@@ -44,6 +46,7 @@ func (m NoOpMapper[T]) ToTransport(
 }
 
 func (m NoOpMapper[T]) FromTransport(
+	_ context.Context,
 	_ stream.ID,
 	payload any,
 ) (stream.Event[T], error) {


### PR DESCRIPTION
__Why?__
Sometimes processing of events loaded from the database may be pretty complex (i.e. requiring another call to the database in order to retrieve the PII secret key). In order to allow conflict-free processing we need to load events from the database first and then process them. Also in order to allow processors to perform external calls and more advanced logic we need to pass a request context to the mappers.

__Tests__
Existing tests were adjusted.