### PR TITLE
Improve transport.Event definition

### DIFF
--- a/_examples/postcard/storage/mapping_postgres_eventstore.go
+++ b/_examples/postcard/storage/mapping_postgres_eventstore.go
@@ -108,6 +108,10 @@ type Created struct {
 	ID string `json:"id"`
 }
 
+func (e *Created) StreamEventName() stream.EventName {
+	return postcard.Created{}.EventName()
+}
+
 func (e *Created) FromStreamEvent(event stream.Event[postcard.Postcard]) {
 	created := event.(postcard.Created)
 	e.ID = created.ID
@@ -122,6 +126,10 @@ func (e *Created) ToStreamEvent() stream.Event[postcard.Postcard] {
 type Addressed struct {
 	Sender    Address `json:"sender"`
 	Addressee Address `json:"addressee"`
+}
+
+func (e *Addressed) StreamEventName() stream.EventName {
+	return postcard.Addressed{}.EventName()
 }
 
 func (e *Addressed) FromStreamEvent(event stream.Event[postcard.Postcard]) {
@@ -148,6 +156,10 @@ type Written struct {
 	Content string `json:"content"`
 }
 
+func (e *Written) StreamEventName() stream.EventName {
+	return postcard.Written{}.EventName()
+}
+
 func (e *Written) FromStreamEvent(event stream.Event[postcard.Postcard]) {
 	written := event.(postcard.Written)
 	e.Content = written.Content
@@ -160,6 +172,10 @@ func (e *Written) ToStreamEvent() stream.Event[postcard.Postcard] {
 }
 
 type Sent struct{}
+
+func (e *Sent) StreamEventName() stream.EventName {
+	return postcard.Sent{}.EventName()
+}
 
 func (e *Sent) FromStreamEvent(_ stream.Event[postcard.Postcard]) {}
 

--- a/transport/default_mapper.go
+++ b/transport/default_mapper.go
@@ -11,6 +11,7 @@ import (
 // Event is a transport model which defines which stream model
 // it corresponds to and implements the mapping from- and to- the stream model.
 type Event[T any] interface {
+	StreamEventName() stream.EventName
 	FromStreamEvent(event stream.Event[T])
 	ToStreamEvent() stream.Event[T]
 }
@@ -28,7 +29,7 @@ func NewDefaultMapper[T any](
 ) DefaultMapper[T] {
 	supported := map[stream.EventName]Event[T]{}
 	for _, e := range supportedEvents {
-		supported[e.ToStreamEvent().EventName()] = e
+		supported[e.StreamEventName()] = e
 	}
 
 	return DefaultMapper[T]{


### PR DESCRIPTION
__Why?__
Previously `DefaultMapper` was using the following logic to register supported `transport.Events` in the constructor:
```
supported := map[stream.EventName]Event[T]{}
for _, e := range supportedEvents {
  supported[e.ToStreamEvent().EventName()] = e
}
```

In case when the invocation of the method `ToStreamEvent()` on empty events was not possible - it could panic as an empty event is not an expected state usually for events - the entire repository construction was panicking.

__What?__
Now each `transport.Event` must provide a method returning the name of an event it corresponds to. 

__Tests__
As the behavior should not change the existing tests already cover that. Only the `_example` events were adjusted to the modified interface.