### PR TITLE
Fix events stored with no stream_type

### DIFF
--- a/_examples/postcard/postcard_test.go
+++ b/_examples/postcard/postcard_test.go
@@ -27,11 +27,13 @@ var (
 
 func TestPostcard_Lifecycle(t *testing.T) {
 	id := uuid.NewString()
+	streamType := "Postcard"
 
 	assert := assert.New(t)
 
 	pc, err := postcard.NewPostcard(id)
 	assert.Equal(id, pc.ID())
+	assert.Equal(streamType, pc.Stream().Type())
 	assert.NoError(err)
 
 	assert.Empty(pc.Addressee())
@@ -58,7 +60,7 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	}
 	assert.Equal(expectedEvents, events)
 
-	pcLoaded, err := esja.NewEntity(id, "", events)
+	pcLoaded, err := esja.NewEntityWithStringType(id, streamType, events)
 	assert.NoError(err)
 
 	assert.Equal(senderAddress, pcLoaded.Sender())

--- a/_examples/postcard/postcard_test.go
+++ b/_examples/postcard/postcard_test.go
@@ -58,7 +58,7 @@ func TestPostcard_Lifecycle(t *testing.T) {
 	}
 	assert.Equal(expectedEvents, events)
 
-	pcLoaded, err := esja.NewEntity(id, events)
+	pcLoaded, err := esja.NewEntity(id, "", events)
 	assert.NoError(err)
 
 	assert.Equal(senderAddress, pcLoaded.Sender())

--- a/entity.go
+++ b/entity.go
@@ -37,6 +37,17 @@ type Entity[T any] interface {
 // so it can record new upcoming stream.
 func NewEntity[T Entity[T]](
 	id string,
+	eventsSlice []VersionedEvent[T],
+) (*T, error) {
+	return NewEntityWithStringType(id, "", eventsSlice)
+}
+
+// NewEntityWithStringType instantiates a new T with the given
+// stream type and events applied to it.
+// At the same time the entity's internal Stream is initialised,
+// so it can record new upcoming stream.
+func NewEntityWithStringType[T Entity[T]](
+	id string,
 	streamType string,
 	eventsSlice []VersionedEvent[T],
 ) (*T, error) {

--- a/entity.go
+++ b/entity.go
@@ -35,10 +35,18 @@ type Entity[T any] interface {
 // NewEntity instantiates a new T with the given events applied to it.
 // At the same time the entity's internal Stream is initialised,
 // so it can record new upcoming stream.
-func NewEntity[T Entity[T]](id string, eventsSlice []VersionedEvent[T]) (*T, error) {
+func NewEntity[T Entity[T]](
+	id string,
+	streamType string,
+	eventsSlice []VersionedEvent[T],
+) (*T, error) {
 	var t T
 
-	stream, err := newStream(id, eventsSlice)
+	stream, err := newStream(
+		id,
+		streamType,
+		eventsSlice,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/eventstore/inmemory.go
+++ b/eventstore/inmemory.go
@@ -9,16 +9,14 @@ import (
 )
 
 type InMemoryStore[T esja.Entity[T]] struct {
-	lock        sync.RWMutex
-	events      map[string][]esja.VersionedEvent[T]
-	streamTypes map[string]string
+	lock   sync.RWMutex
+	events map[string][]esja.VersionedEvent[T]
 }
 
 func NewInMemoryStore[T esja.Entity[T]]() *InMemoryStore[T] {
 	return &InMemoryStore[T]{
-		lock:        sync.RWMutex{},
-		events:      map[string][]esja.VersionedEvent[T]{},
-		streamTypes: map[string]string{},
+		lock:   sync.RWMutex{},
+		events: map[string][]esja.VersionedEvent[T]{},
 	}
 }
 
@@ -31,9 +29,7 @@ func (i *InMemoryStore[T]) Load(_ context.Context, id string) (*T, error) {
 		return nil, ErrEntityNotFound
 	}
 
-	streamType, _ := i.streamTypes[id]
-
-	return esja.NewEntity(id, streamType, events)
+	return esja.NewEntity(id, events)
 }
 
 func (i *InMemoryStore[T]) Save(_ context.Context, t *T) error {
@@ -45,8 +41,6 @@ func (i *InMemoryStore[T]) Save(_ context.Context, t *T) error {
 	}
 
 	stm := *t
-
-	i.streamTypes[stm.Stream().ID()] = stm.Stream().Type()
 
 	events := stm.Stream().PopEvents()
 	if len(events) == 0 {

--- a/eventstore/sql.go
+++ b/eventstore/sql.go
@@ -139,7 +139,7 @@ func (s SQLStore[T]) Load(ctx context.Context, id string) (*T, error) {
 		})
 	}
 
-	return esja.NewEntity(id, streamType, events)
+	return esja.NewEntityWithStringType(id, streamType, events)
 }
 
 // Save saves the entity's queued events to the database.

--- a/eventstore/sql.go
+++ b/eventstore/sql.go
@@ -73,6 +73,7 @@ func (s SQLStore[T]) initializeSchema(ctx context.Context) error {
 type event struct {
 	streamID      string
 	streamVersion int
+	streamType    string
 	eventName     string
 	eventPayload  []byte
 }
@@ -93,13 +94,19 @@ func (s SQLStore[T]) Load(ctx context.Context, id string) (*T, error) {
 		_ = results.Close()
 	}()
 
+	var streamType string
+
 	var dbEvents []event
 	for results.Next() {
 		e := event{}
 
-		err = results.Scan(&e.streamID, &e.streamVersion, &e.eventName, &e.eventPayload)
+		err = results.Scan(&e.streamID, &e.streamVersion, &e.streamType, &e.eventName, &e.eventPayload)
 		if err != nil {
 			return nil, fmt.Errorf("error reading row result: %w", err)
+		}
+
+		if e.streamType != "" {
+			streamType = e.streamType
 		}
 
 		dbEvents = append(dbEvents, e)
@@ -132,7 +139,7 @@ func (s SQLStore[T]) Load(ctx context.Context, id string) (*T, error) {
 		})
 	}
 
-	return esja.NewEntity(id, events)
+	return esja.NewEntity(id, streamType, events)
 }
 
 // Save saves the entity's queued events to the database.

--- a/eventstore/sql_schema_adapter.go
+++ b/eventstore/sql_schema_adapter.go
@@ -11,6 +11,7 @@ const (
 SELECT 
 	stream_id, 
 	stream_version, 
+	stream_type, 
 	event_name, 
 	event_payload
 FROM %s

--- a/stream.go
+++ b/stream.go
@@ -75,15 +75,22 @@ func (s *Stream[T]) HasEvents() bool {
 	return len(s.queue) > 0
 }
 
-func newStream[T any](id string, events []VersionedEvent[T]) (*Stream[T], error) {
+func newStream[T any](id string, st string, events []VersionedEvent[T]) (*Stream[T], error) {
 	if len(events) == 0 {
 		return nil, fmt.Errorf("no stream to load")
 	}
 
-	e, err := NewStream[T](id)
+	var e *Stream[T]
+	var err error
+	if st == "" {
+		e, err = NewStream[T](id)
+	} else {
+		e, err = NewStreamWithType[T](id, st)
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	e.version = events[len(events)-1].StreamVersion
 	e.queue = events
 


### PR DESCRIPTION
This is a bug-fix for https://github.com/ThreeDotsLabs/esja/issues/31

The root problem was the fact that when loading events from the DB and creating a new instance of an Entity with stream injected, the `stream_type` property was ignored. In consequence, a new instance was created with empty `stream_type` and all of the subsequent events were stored without it.

I run the tests before and after the change and it proves the issue is gone now.
__Before__
![image](https://user-images.githubusercontent.com/5250697/216589443-08533e1f-6fbb-4aad-9638-eafa15e790a8.png)

__After__
![image](https://user-images.githubusercontent.com/5250697/216589478-09180b93-0c20-4c97-8f10-6c6a8803d072.png)